### PR TITLE
Quick hack to allow a perl build to succeed and mechacpan be useful immediately afterwards.

### DIFF
--- a/lib/App/MechaCPAN.pm
+++ b/lib/App/MechaCPAN.pm
@@ -166,6 +166,7 @@ sub main
 
     my $log_path;
     ( $LOGFH, $log_path ) = tempfile( "$log_dir/log.$$.XXXX", UNLINK => 0 );
+    print "logging to '$log_path'...\n";
   }
 
   my $ret = eval { $pkg->$action( $options, @argv ) || 0; };


### PR DESCRIPTION
Hi atrodo,

In an effort to use App::MechaCPAN in a docker environment or just at the command line in a Debian/CentOS box, I needed to work around the error that would happen when just doing a 'mechacpan perl ....' where it would say 'App::MechaCPAN not found' upon restart of the script.  This would prevent any automated steps from continuing.

I did a quick hack, utilizing shell commands, to do the file copies.   This solved the first problem and allowed me to immediately use 'mechacpan install ...' instead of having to worry about installing App::MechaCPAN into the newly built local/ directory.

Then, when I was trying to install packages and kept getting errors, I quickly got tired of trying to find the most recent log in the logs/ directory, so I had it always display the file it's logging to.  This is very useful.

In an attempt to get Image::Magick installed, I tried building perl as a shared lib install but I think the Makefile.PL is leaving out something critical to the 'ld command', so it can't find -lperl.  I figured --shared-lib was a useful build option so I fleshed out the POD for that.